### PR TITLE
augment audio module docstring

### DIFF
--- a/docs/reference/include/openai.resources.py
+++ b/docs/reference/include/openai.resources.py
@@ -8,15 +8,29 @@ The submodules' classes mirror the structure of the API's endpoints and offer sy
 communication with the API.
 
 Each resource is accessible as an attribute on the [`OpenAI`][src.openai.OpenAI] and [`AsyncOpenAI`][src.openai.AsyncOpenAI]
-clients. To work with a resource, initialize an instance of one of the clients and access the resource as an attribute
+clients. To work with a resource, initialize an instance of a client and then access the resource as an attribute
 on the client instance. For example, to work with the `chat` resource, create an instance of the `OpenAI` client and
 access the attributes and methods on `your_client_instance.chat`.
 # --8<-- [end:resources]
 
 # --8<-- [start:audio]
-The `audio` module provides classes for handling various audio processing operations, including transcription of audio to text, translation of spoken content, and speech synthesis.
+The `audio` module provides classes for audio processing operations like transcription, translation, and speech synthesis.
 
-This module supports synchronous and asynchronous operations, and offers interfaces for direct interaction with audio data, as well as handling of raw and streaming responses. Designed for applications that require audio input processing like automated transcription services, real-time translation of spoken language, and generating spoken content from text.
+Use the `audio` module by accessing the [`OpenAI.audio`][src.openai.OpenAI.audio] attribute on the client object, and
+then access the attribute for the feature you'd like to use:
+
+- [`OpenAI.audio.transcriptions`][src.openai.resources.Audio.transcriptions] - Transcribe spoken audio to text
+- [`OpenAI.audio.translations`][src.openai.resources.Audio.translations] - Translate spoken audio to English
+- [`OpenAI.audio.speech`][src.openai.resources.Audio.speech] - Generate spoken audio from text
+
+Examples:
+    ```python
+    --8<-- "./examples/audio_docs.py:common_imports"
+
+    --8<-- "./examples/audio_docs.py:common_setup"
+
+    --8<-- "./examples/audio_docs.py:speech"
+    ```
 # --8<-- [end:audio]
 
 # --8<-- [start:beta]
@@ -40,11 +54,11 @@ This module interacts with the `/v1/chat/completions` endpoint and replaces the 
 # --8<-- [end:chat_completions]
 
 # --8<-- [start:completions]
-The `completions` module provides access to the legacy completions endpoint of the OpenAI API. Use the [`chat.completions`][src.openai.resources.chat.completions] module instead for new applications.
+The `completions` module provides access to the [legacy](https://platform.openai.com/docs/deprecations) chat endpoint, `/v1/completions`. Use the [`chat.completions`][src.openai.resources.chat.completions] module instead for new applications.
 
-This module interacts with a [legacy](https://platform.openai.com/docs/deprecations) endpoint,  `/v1/completions`, indicating that the endpoint no longer receives updates and is expected to be deprecated. This module is for use only in applications that require compatibility with the legacy endpoint and should **not** be used for new projects.
+You should **not** use this module for new projects. The legacy `/v1/completions` endpoint this module interacts with no longer receives updates and is expected to be deprecated. Use this module only in applications that require compatibility with the legacy endpoint.
 
-You're *strongly encouraged* to migrate existing applications to the [`chat.completions`][src.openai.resources.chat.completions] module⁠—which interacts with the current (non-legacy) `/v1/chat/completions` endpoint—prior to the [deprecation](https://platform.openai.com/docs/deprecations) of the `/v1/completions` endpoint.
+You're *strongly* encouraged to migrate existing applications to the [`chat.completions`][src.openai.resources.chat.completions] module⁠—which interacts with the current (non-legacy) `/v1/chat/completions` endpoint—prior to the [deprecation](https://platform.openai.com/docs/deprecations) of the `/v1/completions` endpoint.
 # --8<-- [end:completions]
 
 # --8<-- [start:embeddings]

--- a/examples/audio_docs.py
+++ b/examples/audio_docs.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env rye run python
+# --8<-- [start:common_imports]
+from pathlib import Path
+
+from openai import OpenAI
+# --8<-- [end:common_imports]
+
+# --8<-- [start:common_setup]
+openai = OpenAI()
+
+speech_file_path = Path(__file__).parent / "speech.mp3"
+# --8<-- [end:common_setup]
+
+def main() -> None:
+
+    stream_to_speakers()
+
+    # --8<-- [start:speech]
+    # Create text-to-speech audio file
+    with openai.audio.speech.with_streaming_response.create(
+        model="tts-1",
+        voice="alloy",
+        input="The quick brown fox jumps over the lazy dog.",
+    ) as response:
+        response.stream_to_file(speech_file_path)
+    # --8<-- [end:speech]
+
+    # --8<-- [start:transcription]
+    # Create transcription from audio file
+    transcription = openai.audio.transcriptions.create(
+        model="whisper-1",
+        file=speech_file_path,
+    )
+    print(transcription.text)
+    # --8<-- [end:transcription]
+
+    # --8<-- [start:translation]
+    # Create translation from audio file
+    translation = openai.audio.translations.create(
+        model="whisper-1",
+        file=speech_file_path,
+    )
+    print(translation.text)
+    # --8<-- [end:translation]
+
+# --8<-- [start:speech.with_streaming_response]
+def stream_to_speakers() -> None:
+    import pyaudio
+    import time
+
+    player_stream = pyaudio.PyAudio().open(format=pyaudio.paInt16, channels=1, rate=24000, output=True)
+
+    start_time = time.time()
+
+    with openai.audio.speech.with_streaming_response.create(
+        model="tts-1",
+        voice="alloy",
+        response_format="pcm",  # similar to WAV, but without a header chunk at the start.
+        input="""I see skies of blue and clouds of white
+                The bright blessed days, the dark sacred nights
+                And I think to myself
+                What a wonderful world""",
+    ) as response:
+        print(f"Time to first byte: {int((time.time() - start_time) * 1000)}ms")
+        for chunk in response.iter_bytes(chunk_size=1024):
+            player_stream.write(chunk)
+
+    print(f"Done in {int((time.time() - start_time) * 1000)}ms.")
+# --8<-- [end:speech.with_streaming_response]
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: OpenAI Python library documentation · UNOFFICIAL
+site_name: OpenAI Python library · UNOFFICIAL DOCS
 site_author: Marsh Macy
 site_description: Unofficial documentation for OpenAI's Python library
 site_url: https://mmacy.github.io/openai-python/
@@ -116,6 +116,8 @@ extra:
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/mmacy
+#  version:
+#    provider: mike
 
 nav:
   - Welcome:


### PR DESCRIPTION
- Dupes the `examples/audio.py` file and adds snippet markers for inclusion in API reference docstrings
- Enhances the `audio` module docstring with a clearer description, a usage example, and descriptions of its submodules
- Modifies documentation title to use "UNOFFICIAL DOCS" suffix (slightly clearer)