### PR TITLE
versioning config (mike)

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+
+{% block outdated %}
+  This document is for a version of the library other than the latest (current) version.
+  <a href="{{ '../' ~ base_url }}">
+    <strong>Take me to the current version's docs.</strong>
+  </a>
+{% endblock %}

--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -14,11 +14,14 @@ h11==0.14.0
 httpcore==1.0.3
 httpx==0.26.0
 idna==3.6
+importlib_metadata==7.0.2
+importlib_resources==6.1.3
 iniconfig==2.0.0
 Jinja2==3.1.3
 Markdown==3.5.2
 MarkupSafe==2.1.5
 mergedeep==1.3.4
+mike==2.0.0
 mkdocs==1.5.3
 mkdocs-autorefs==0.5.0
 mkdocs-gen-files==0.5.0
@@ -38,6 +41,7 @@ pydantic==2.6.1
 pydantic_core==2.16.2
 Pygments==2.17.2
 pymdown-extensions==10.7
+pyparsing==3.1.2
 pytest==8.0.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
@@ -50,4 +54,6 @@ sniffio==1.3.0
 tqdm==4.66.2
 typing_extensions==4.9.0
 urllib3==2.2.0
+verspec==0.1.0
 watchdog==4.0.0
+zipp==3.17.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ watch: [README.md, src/openai]
 
 theme:
   name: material
+  custom_dir: docs/overrides
   icon:
     repo: fontawesome/brands/git-alt
 
@@ -28,12 +29,8 @@ theme:
         name: Switch to light mode
 
   font:
-    #text: Sora # BIG!
     text: Inter
-    #text: Actor
-
     code: Chivo Mono
-    #code: Martian Mono # BIG!
 
   features:
     - content.code.annotate
@@ -116,8 +113,8 @@ extra:
   social:
   - icon: fontawesome/brands/github
     link: https://github.com/mmacy
-#  version:
-#    provider: mike
+  version:
+    provider: mike
 
 nav:
   - Welcome:


### PR DESCRIPTION
Fixes #6 

- Enables [versioning of the docs](https://squidfunk.github.io/mkdocs-material/setup/setting-up-versioning/) with [mike](https://github.com/jimporter/mike).

The first version of the library/library docs that uses this is 1.13.3.

> [!NOTE]
> Versioning seems a little wonky with only one version. For example, clicking on the version selector with only 1.13.3 published exhibits busted redirect behavior, but hopefully that straightens out when I publish the next version. We'll see... 🎲 *rolls dice* 🎲 